### PR TITLE
Add insecure vs secure login and form demos

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,9 @@
-# Mobile-app
+# Iron Dillo Mobile App
+
+This repository hosts demo pages for illustrating common security pitfalls and their fixes.
+
+- `insecure/login.html` and `secure/login.html` show an unsecured login with hardcoded credentials and a patched version using HTTPS, random credentials, and secure cookies.
+- `insecure/form.html` and `secure/form.html` demonstrate form handling over HTTP versus HTTPS with proper cookie protection.
+- `SECURITY_DEMO.md` provides side-by-side code snippets explaining each fix.
+
+Veteran-owned cybersecurity for East Texas small businesses, individuals, and rural operations — proudly serving Lindale and Tyler.

--- a/SECURITY_DEMO.md
+++ b/SECURITY_DEMO.md
@@ -1,0 +1,52 @@
+# Security Demo
+
+This demo illustrates common web security issues and their fixes for the Iron Dillo website.
+
+## Login Example
+
+| Insecure | Secure |
+| --- | --- |
+| ```html
+<form action="http://example.com/login" method="POST">
+  ...
+</form>
+<script>
+const USER = 'admin';
+const PASS = 'password123';
+document.cookie = "session=abc123";
+</script>
+``` | ```html
+<form action="https://example.com/login" method="POST">
+  ...
+</form>
+<script>
+const USER = crypto.randomUUID();
+const PASS = crypto.randomUUID();
+document.cookie = "session=" + crypto.randomUUID() + "; Secure; SameSite=Strict";
+</script>
+``` |
+
+Hardcoded credentials, plain HTTP, and an unencrypted cookie expose user data. Using HTTPS, random credentials, and secure cookies protects sessions.
+
+## Contact Form Example
+
+| Insecure | Secure |
+| --- | --- |
+| ```html
+<form action="http://example.com/contact" method="POST">
+  ...
+</form>
+<script>
+document.cookie = "prefs=dark";
+</script>
+``` | ```html
+<form action="https://example.com/contact" method="POST">
+  ...
+</form>
+<script>
+document.cookie = "prefs=" + encodeURIComponent(JSON.stringify({theme:'dark'})) + "; Secure; SameSite=Lax";
+</script>
+``` |
+
+Sending form data over HTTP and storing unencrypted cookies allows interception. HTTPS and secure cookies keep information private.
+

--- a/insecure/form.html
+++ b/insecure/form.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta http-equiv="X-Content-Type-Options" content="nosniff">
+  <meta http-equiv="Referrer-Policy" content="no-referrer">
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self';">
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;700&display=swap" rel="stylesheet">
+  <script src="https://cdn.tailwindcss.com"></script>
+  <script>
+    tailwind.config = { theme: { extend: { colors: { armadilloBlack: '#1A1A1A', armadilloGray: '#4A4A4A', oliveGreen: '#6B7B3C', oliveDark: '#55622F', offWhite: '#F8F9FA' } } } };
+  </script>
+  <title>Insecure Form</title>
+</head>
+<body class="bg-offWhite font-[Inter] text-armadilloBlack">
+  <header class="p-4 flex items-center">
+    <img src="../logo.svg" alt="Iron Dillo logo" class="h-8 w-8 mr-2">
+    <h1 class="text-xl font-bold">Insecure Form Demo</h1>
+  </header>
+  <main class="max-w-md mx-auto p-4">
+    <p class="mb-4">Veteran-owned cybersecurity for East Texas small businesses, individuals, and rural operations — serving Lindale and Tyler.</p>
+    <form class="space-y-4" action="http://example.com/contact" method="POST">
+      <input type="text" name="name" placeholder="Name" class="w-full p-2 border">
+      <input type="email" name="email" placeholder="Email" class="w-full p-2 border">
+      <textarea name="message" placeholder="Message" class="w-full p-2 border"></textarea>
+      <button class="bg-oliveGreen text-offWhite px-4 py-2" type="submit">Send</button>
+    </form>
+    <p class="mt-4 text-sm text-armadilloGray">This form sends data over HTTP and stores preferences in an unencrypted cookie.</p>
+  </main>
+  <script>
+    document.cookie = "prefs=dark";
+  </script>
+</body>
+</html>

--- a/insecure/login.html
+++ b/insecure/login.html
@@ -1,0 +1,46 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta http-equiv="X-Content-Type-Options" content="nosniff">
+  <meta http-equiv="Referrer-Policy" content="no-referrer">
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self';">
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;700&display=swap" rel="stylesheet">
+  <script src="https://cdn.tailwindcss.com"></script>
+  <script>
+    tailwind.config = { theme: { extend: { colors: { armadilloBlack: '#1A1A1A', armadilloGray: '#4A4A4A', oliveGreen: '#6B7B3C', oliveDark: '#55622F', offWhite: '#F8F9FA' } } } };
+  </script>
+  <title>Insecure Login</title>
+</head>
+<body class="bg-offWhite font-[Inter] text-armadilloBlack">
+  <header class="p-4 flex items-center">
+    <img src="../logo.svg" alt="Iron Dillo logo" class="h-8 w-8 mr-2">
+    <h1 class="text-xl font-bold">Insecure Login Demo</h1>
+  </header>
+  <main class="max-w-md mx-auto p-4">
+    <p class="mb-4">Veteran-owned cybersecurity for East Texas small businesses, individuals, and rural operations — serving Lindale and Tyler.</p>
+    <form class="space-y-4" action="http://example.com/login" method="POST">
+      <input type="text" name="username" placeholder="Username" class="w-full p-2 border">
+      <input type="password" name="password" placeholder="Password" class="w-full p-2 border">
+      <button class="bg-oliveGreen text-offWhite px-4 py-2" type="submit">Login</button>
+    </form>
+    <p class="mt-4 text-sm text-armadilloGray">This example uses hardcoded credentials and sets an unencrypted cookie.</p>
+  </main>
+  <script>
+    const USER = 'admin';
+    const PASS = 'password123';
+    document.querySelector('form').addEventListener('submit', (e) => {
+      e.preventDefault();
+      const u = e.target.username.value;
+      const p = e.target.password.value;
+      if (u === USER && p === PASS) {
+        document.cookie = "session=abc123";
+        alert('Logged in with insecure credentials!');
+      } else {
+        alert('Invalid credentials');
+      }
+    });
+  </script>
+</body>
+</html>

--- a/logo.svg
+++ b/logo.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 50">
+  <rect width="100" height="50" fill="#1A1A1A"/>
+  <text x="10" y="35" font-family="Inter" font-size="30" fill="#6B7B3C">ID</text>
+</svg>

--- a/secure/form.html
+++ b/secure/form.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta http-equiv="X-Content-Type-Options" content="nosniff">
+  <meta http-equiv="Referrer-Policy" content="no-referrer">
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self';">
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;700&display=swap" rel="stylesheet">
+  <script src="https://cdn.tailwindcss.com"></script>
+  <script>
+    tailwind.config = { theme: { extend: { colors: { armadilloBlack: '#1A1A1A', armadilloGray: '#4A4A4A', oliveGreen: '#6B7B3C', oliveDark: '#55622F', offWhite: '#F8F9FA' } } } };
+  </script>
+  <title>Secure Form</title>
+</head>
+<body class="bg-offWhite font-[Inter] text-armadilloBlack">
+  <header class="p-4 flex items-center">
+    <img src="../logo.svg" alt="Iron Dillo logo" class="h-8 w-8 mr-2">
+    <h1 class="text-xl font-bold">Secure Form Demo</h1>
+  </header>
+  <main class="max-w-md mx-auto p-4">
+    <p class="mb-4">Veteran-owned cybersecurity for East Texas small businesses, individuals, and rural operations — serving Lindale and Tyler.</p>
+    <form class="space-y-4" action="https://example.com/contact" method="POST">
+      <input type="text" name="name" placeholder="Name" class="w-full p-2 border">
+      <input type="email" name="email" placeholder="Email" class="w-full p-2 border">
+      <textarea name="message" placeholder="Message" class="w-full p-2 border"></textarea>
+      <button class="bg-oliveGreen text-offWhite px-4 py-2" type="submit">Send</button>
+    </form>
+    <p class="mt-4 text-sm text-armadilloGray">This form enforces HTTPS and stores preferences in a secure cookie.</p>
+  </main>
+  <script>
+    document.cookie = "prefs=" + encodeURIComponent(JSON.stringify({theme:'dark'})) + "; Secure; SameSite=Lax";
+  </script>
+</body>
+</html>

--- a/secure/login.html
+++ b/secure/login.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta http-equiv="X-Content-Type-Options" content="nosniff">
+  <meta http-equiv="Referrer-Policy" content="no-referrer">
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self';">
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;700&display=swap" rel="stylesheet">
+  <script src="https://cdn.tailwindcss.com"></script>
+  <script>
+    tailwind.config = { theme: { extend: { colors: { armadilloBlack: '#1A1A1A', armadilloGray: '#4A4A4A', oliveGreen: '#6B7B3C', oliveDark: '#55622F', offWhite: '#F8F9FA' } } } };
+  </script>
+  <title>Secure Login</title>
+</head>
+<body class="bg-offWhite font-[Inter] text-armadilloBlack">
+  <header class="p-4 flex items-center">
+    <img src="../logo.svg" alt="Iron Dillo logo" class="h-8 w-8 mr-2">
+    <h1 class="text-xl font-bold">Secure Login Demo</h1>
+  </header>
+  <main class="max-w-md mx-auto p-4">
+    <p class="mb-4">Veteran-owned cybersecurity for East Texas small businesses, individuals, and rural operations — serving Lindale and Tyler.</p>
+    <form class="space-y-4" action="https://example.com/login" method="POST">
+      <input type="text" name="username" placeholder="Username" class="w-full p-2 border">
+      <input type="password" name="password" placeholder="Password" class="w-full p-2 border">
+      <button class="bg-oliveGreen text-offWhite px-4 py-2" type="submit">Login</button>
+    </form>
+    <p class="mt-4 text-sm text-armadilloGray">This example enforces HTTPS, uses random credentials, and sets a secure cookie.</p>
+  </main>
+  <script>
+    const USER = crypto.randomUUID();
+    const PASS = crypto.randomUUID();
+    document.querySelector('form').addEventListener('submit', (e) => {
+      e.preventDefault();
+      document.cookie = "session=" + crypto.randomUUID() + "; Secure; SameSite=Strict";
+      alert('Logged in securely!');
+    });
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Add insecure login and form examples with HTTP, hardcoded credentials, and plain cookies
- Add secure counterparts using HTTPS, random credentials, and secure cookies
- Document differences with side-by-side code snippets

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a695e2ce708322bc18dd395cd4ea38