### PR TITLE
Add XSS demo with insecure components and secure toggle

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,0 +1,33 @@
+window.addEventListener('alpine:init', () => {
+  Alpine.data('xssDemo', () => ({
+    secure: false,
+    comments: [],
+    commentInput: '',
+    searchInput: '',
+    searchResultDisplay: '',
+    escapeHTML(str) {
+      return str
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;')
+        .replace(/"/g, '&quot;')
+        .replace(/'/g, '&#039;');
+    },
+    addComment() {
+      this.comments.push(this.commentInput);
+      this.commentInput = '';
+    },
+    doSearch() {
+      this.searchResultDisplay = `Results for "${this.searchInput}"`;
+    },
+    toggleSecure() {
+      this.secure = !this.secure;
+      const cspMeta = document.getElementById('csp');
+      if (this.secure) {
+        cspMeta.setAttribute('content', "default-src 'self' https://cdn.tailwindcss.com https://unpkg.com https://fonts.googleapis.com https://fonts.gstatic.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; script-src 'self' https://cdn.tailwindcss.com https://unpkg.com;");
+      } else {
+        cspMeta.setAttribute('content', '');
+      }
+    }
+  }));
+});

--- a/favicon.svg
+++ b/favicon.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <rect width="64" height="64" fill="#6B7B3C"/>
+  <circle cx="32" cy="32" r="20" fill="#F8F9FA"/>
+  <path d="M20 40 L32 20 L44 40 Z" fill="#1A1A1A"/>
+</svg>

--- a/index.html
+++ b/index.html
@@ -1,0 +1,72 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Iron Dillo XSS Demo</title>
+  <meta id="csp" http-equiv="Content-Security-Policy" content="">
+  <link rel="icon" type="image/svg+xml" href="favicon.svg">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap" rel="stylesheet">
+  <script src="https://cdn.tailwindcss.com"></script>
+  <script src="https://unpkg.com/alpinejs@3.x.x/dist/cdn.min.js" defer></script>
+  <script>
+    tailwind.config = {
+      theme: {
+        extend: {
+          colors: {
+            armadilloBlack: '#1A1A1A',
+            armadilloGray: '#4A4A4A',
+            oliveGreen: '#6B7B3C',
+            oliveDark: '#55622F',
+            offWhite: '#F8F9FA'
+          }
+        }
+      }
+    }
+  </script>
+  <script src="app.js" defer></script>
+</head>
+<body class="bg-offWhite text-armadilloBlack font-[Inter]" x-data="xssDemo">
+  <header class="flex items-center p-4 bg-armadilloBlack text-offWhite">
+    <img src="logo.svg" alt="Iron Dillo logo" class="h-8 w-8 mr-2">
+    <h1 class="text-xl font-bold">Iron Dillo Cybersecurity</h1>
+    <div class="ml-auto flex items-center">
+      <label for="secureToggle" class="mr-2">Secure View</label>
+      <input type="checkbox" id="secureToggle" class="h-4 w-4" x-on:change="toggleSecure()">
+    </div>
+  </header>
+  <main class="p-4 space-y-8">
+    <section>
+      <h2 class="text-lg font-semibold">Comments (Stored XSS Demo)</h2>
+      <div class="mt-2">
+        <textarea x-model="commentInput" class="w-full border p-2" placeholder="Add a comment"></textarea>
+        <button x-on:click="addComment" class="mt-2 px-4 py-2 bg-oliveGreen text-offWhite">Post</button>
+      </div>
+      <ul class="mt-4 space-y-2">
+        <template x-for="c in comments" :key="c">
+          <li x-html="secure ? escapeHTML(c) : c"></li>
+        </template>
+      </ul>
+      <p class="text-sm text-oliveDark mt-2">
+        Hint: Try &lt;script&gt;alert('Stored XSS')&lt;/script&gt;. 
+        Remediation: escape user input &amp; enforce CSP.
+      </p>
+    </section>
+    <section>
+      <h2 class="text-lg font-semibold">Search (Reflected XSS Demo)</h2>
+      <div class="mt-2 flex">
+        <input x-model="searchInput" class="flex-1 border p-2" placeholder="Search term">
+        <button x-on:click="doSearch" class="ml-2 px-4 py-2 bg-oliveGreen text-offWhite">Go</button>
+      </div>
+      <div x-html="secure ? escapeHTML(searchResultDisplay) : searchResultDisplay" x-ref="searchResult" class="mt-4"></div>
+      <p class="text-sm text-oliveDark mt-2">
+        Hint: Search for &lt;script&gt;alert('Reflected XSS')&lt;/script&gt;.
+        Remediation: escape query parameters &amp; enforce CSP.
+      </p>
+    </section>
+  </main>
+  <footer class="text-center text-sm text-armadilloGray mt-8">Serving Lindale and Tyler, TX</footer>
+</body>
+</html>

--- a/logo.svg
+++ b/logo.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <rect width="64" height="64" fill="#6B7B3C"/>
+  <circle cx="32" cy="32" r="20" fill="#F8F9FA"/>
+  <path d="M20 40 L32 20 L44 40 Z" fill="#1A1A1A"/>
+</svg>


### PR DESCRIPTION
## Summary
- Demonstrate stored and reflected XSS via unsanitized comment and search components
- Add secure view toggle applying CSP and escaping helpers
- Include UI hints with remediation guidance for both XSS scenarios

## Testing
- `npm test` *(fails: ENOENT could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a695e82e7483229a31ad4e17cf7ed5