### PR TITLE
Add session security demo with predictable and secure cookies

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,4 @@
 # Mobile-app
+
+This repository includes a session security demonstration for the Iron Dillo Cybersecurity site.
+Open `session-demo.html` in a browser to explore predictable versus secure session handling with explanatory security headers.

--- a/armadillo.svg
+++ b/armadillo.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 32" fill="#6B7B3C">
+  <ellipse cx="20" cy="16" rx="18" ry="14"/>
+  <rect x="32" y="12" width="20" height="8" rx="4"/>
+  <circle cx="58" cy="16" r="4"/>
+</svg>

--- a/session-demo.html
+++ b/session-demo.html
@@ -1,0 +1,50 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>Session Security Demo | Iron Dillo Cybersecurity</title>
+  <meta name="description" content="Demonstration of insecure and secure session handling">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' https://cdn.jsdelivr.net; style-src 'self' https://cdn.jsdelivr.net https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self';">
+  <meta http-equiv="X-Content-Type-Options" content="nosniff">
+  <meta http-equiv="X-Frame-Options" content="DENY">
+  <meta name="referrer" content="no-referrer">
+  <link rel="icon" type="image/svg+xml" href="armadillo.svg">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&display=swap" rel="stylesheet">
+  <script src="https://cdn.tailwindcss.com"></script>
+  <script defer src="https://cdn.jsdelivr.net/npm/alpinejs@3.x.x/dist/cdn.min.js"></script>
+  <style>
+    body {font-family: 'Inter', sans-serif;}
+  </style>
+</head>
+<body class="bg-[#F8F9FA] text-[#1A1A1A]">
+  <div class="max-w-3xl mx-auto p-6 space-y-10" x-data="{ token:null, stolen:null }">
+    <header class="flex items-center space-x-4">
+      <img src="armadillo.svg" alt="Iron Dillo logo" class="w-12 h-12">
+      <h1 class="text-2xl font-semibold text-[#6B7B3C]">Session Security Demo</h1>
+    </header>
+
+    <section class="space-y-4">
+      <h2 class="text-xl font-semibold text-[#55622F]">Insecure: Predictable Tokens</h2>
+      <p class="text-[#4A4A4A]">This example issues a predictable cookie that can be read and stolen from JavaScript.</p>
+      <div class="flex flex-wrap gap-2">
+        <button class="px-3 py-2 bg-[#6B7B3C] text-white rounded" @click="token='12345'; document.cookie='session='+token">Login (Insecure)</button>
+        <button class="px-3 py-2 bg-[#4A4A4A] text-white rounded" @click="stolen=document.cookie">Steal Session</button>
+        <button class="px-3 py-2 bg-[#55622F] text-white rounded" @click="token=Math.random().toString(36).slice(2); document.cookie='session='+token">Fix Session</button>
+      </div>
+      <p class="text-sm text-[#4A4A4A]" x-text="'Current cookie: '+document.cookie"></p>
+      <p class="text-sm text-red-700" x-show="stolen" x-text="'Stolen token: '+stolen"></p>
+      <p class="text-xs text-[#4A4A4A]">Cookie set without security flags allows XSS to read and reuse the token.</p>
+    </section>
+
+    <section class="space-y-4">
+      <h2 class="text-xl font-semibold text-[#55622F]">Secure Alternative</h2>
+      <p class="text-[#4A4A4A]">Sessions should use unpredictable identifiers in cookies with security flags. Example server response:</p>
+      <pre class="bg-white p-4 rounded border border-[#4A4A4A] overflow-x-auto text-sm"><code>Set-Cookie: session=&lt;random&gt;; HttpOnly; Secure; SameSite=Strict; Path=/;</code></pre>
+      <p class="text-[#4A4A4A] text-sm">The <code>HttpOnly</code> flag prevents JavaScript access, <code>Secure</code> restricts cookies to HTTPS, and <code>SameSite=Strict</code> mitigates CSRF.</p>
+    </section>
+  </div>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add interactive session handling demo using predictable tokens to illustrate theft and regeneration
- show secure alternative with randomized HttpOnly SameSite cookie example
- include brand assets, Tailwind, Alpine, and security headers

## Testing
- `npm test` *(fails: npm: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68a695f36e688322ae6434ec946399a2