### PR TITLE
Add demo server with toggleable security settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,28 @@
-# Mobile-app
+# Demo Server Security Modes
+
+This repository demonstrates directory indexing and detailed error pages in a demo environment and provides a secure mode that disables listings and masks errors.
+
+## Usage
+
+Run in demo mode (default):
+
+```
+node server.js
+```
+
+Directory contents are listed and stack traces are returned on errors.
+
+Run in secure mode:
+
+```
+SECURE=true node server.js
+```
+
+Directory listing is disabled and users see a generic error message.
+
+## Security Notes
+
+- **Directory Listing**: Attackers can enumerate files to find backups, configuration files, or other sensitive data, which aids targeted exploitation.
+- **Detailed Error Messages**: Verbose stack traces disclose implementation details useful for SQL injection, path traversal, or framework-specific attacks.
+
+Switching to secure mode mitigates these information disclosure vectors.

--- a/public/index.html
+++ b/public/index.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Demo</title>
+</head>
+<body>
+  <h1>Demo Directory</h1>
+</body>
+</html>

--- a/server.js
+++ b/server.js
@@ -1,0 +1,49 @@
+const http = require('http');
+const fs = require('fs');
+const path = require('path');
+const url = require('url');
+
+const PORT = process.env.PORT || 3000;
+const ROOT = path.join(__dirname, 'public');
+const SECURE = process.env.SECURE === 'true';
+
+function sendError(res, err) {
+  if (SECURE) {
+    res.writeHead(500, { 'Content-Type': 'text/plain' });
+    res.end('Internal Server Error');
+  } else {
+    res.writeHead(500, { 'Content-Type': 'text/plain' });
+    res.end(err.stack);
+  }
+}
+
+const server = http.createServer((req, res) => {
+  const parsedUrl = url.parse(req.url);
+  const pathname = decodeURIComponent(parsedUrl.pathname);
+  const fsPath = path.join(ROOT, pathname);
+
+  fs.stat(fsPath, (err, stats) => {
+    if (err) return sendError(res, err);
+
+    if (stats.isDirectory()) {
+      if (SECURE) {
+        res.writeHead(403, { 'Content-Type': 'text/plain' });
+        res.end('Forbidden');
+      } else {
+        fs.readdir(fsPath, (err, files) => {
+          if (err) return sendError(res, err);
+          res.writeHead(200, { 'Content-Type': 'text/html' });
+          res.end('<ul>' + files.map(f => `<li><a href="${path.join(pathname, f)}">${f}</a></li>`).join('') + '</ul>');
+        });
+      }
+    } else {
+      const stream = fs.createReadStream(fsPath);
+      stream.on('error', err => sendError(res, err));
+      stream.pipe(res);
+    }
+  });
+});
+
+server.listen(PORT, () => {
+  console.log(`Server running on port ${PORT} in ${SECURE ? 'secure' : 'demo'} mode`);
+});


### PR DESCRIPTION
## Summary
- add Node demo server that lists directories and shows stack traces in demo mode
- provide SECURE toggle to disable directory listing and mask errors
- document attack vectors and how secure mode mitigates them

## Testing
- `node server.js`
- `SECURE=true node server.js`


------
https://chatgpt.com/codex/tasks/task_e_68a695fb654c83229ddeff3fc9aa44eb