### PR TITLE
Implement lab reset dispatcher and UI control

### DIFF
--- a/labs/__init__.py
+++ b/labs/__init__.py
@@ -1,0 +1,24 @@
+"""Utilities for managing lab state."""
+import importlib
+import pkgutil
+from types import ModuleType
+from typing import List
+
+
+def _iter_state_modules() -> List[ModuleType]:
+    """Yield each lab's state module if it defines `reset`."""
+    modules = []
+    for pkg in pkgutil.iter_modules(__path__):
+        try:
+            mod = importlib.import_module(f"{__name__}.{pkg.name}.state")
+        except ModuleNotFoundError:
+            continue
+        if hasattr(mod, "reset") and callable(mod.reset):
+            modules.append(mod)
+    return modules
+
+
+def reset_all() -> None:
+    """Call `reset()` for every lab that defines it."""
+    for mod in _iter_state_modules():
+        mod.reset()

--- a/labs/example/state.py
+++ b/labs/example/state.py
@@ -1,0 +1,17 @@
+"""State management for the example lab."""
+
+class ExampleState:
+    """Trivial state container used for demonstration."""
+    def __init__(self) -> None:
+        self.counter = 0
+
+    def reset(self) -> None:
+        """Reset the lab's internal state."""
+        self.counter = 0
+
+state = ExampleState()
+
+
+def reset() -> None:
+    """Module-level helper for resetting this lab's state."""
+    state.reset()

--- a/public/logo.svg
+++ b/public/logo.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+  <rect width="100" height="100" fill="#6B7B3C" />
+  <text x="50" y="60" text-anchor="middle" font-size="50" fill="#F8F9FA">A</text>
+</svg>

--- a/terminal/__init__.py
+++ b/terminal/__init__.py
@@ -1,0 +1,1 @@
+"""Terminal package for command dispatching."""

--- a/terminal/cli.py
+++ b/terminal/cli.py
@@ -1,0 +1,30 @@
+"""Command dispatcher for terminal input."""
+from typing import Callable, Dict, Any
+
+from labs import reset_all
+
+CommandHandler = Callable[..., Any]
+
+# Mapping of allowed command names to their handlers
+COMMANDS: Dict[str, CommandHandler] = {}
+
+def register_command(name: str, handler: CommandHandler) -> None:
+    """Register a handler for a command."""
+    COMMANDS[name] = handler
+
+def dispatch(command: str, *args, **kwargs):
+    """Dispatch a command to its handler."""
+    try:
+        handler = COMMANDS[command]
+    except KeyError as exc:  # pragma: no cover - minimal error handling
+        raise ValueError(f"Unsupported command: {command}") from exc
+    return handler(*args, **kwargs)
+
+
+def _reset_handler() -> str:
+    """Reset all labs and return a confirmation message."""
+    reset_all()
+    return "Reset complete."
+
+# Register built-in commands
+register_command("reset", _reset_handler)

--- a/ui/app.js
+++ b/ui/app.js
@@ -1,0 +1,13 @@
+function callPythonReset() {
+  if (window.pyodide) {
+    window.pyodide.runPython('from labs import reset_all; reset_all()');
+  }
+}
+
+const resetBtn = document.getElementById('reset');
+const terminal = document.getElementById('terminal');
+
+resetBtn.addEventListener('click', () => {
+  callPythonReset();
+  terminal.innerHTML = '';
+});

--- a/ui/index.html
+++ b/ui/index.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com https://cdn.tailwindcss.com; font-src https://fonts.gstatic.com; script-src 'self' https://cdn.tailwindcss.com" />
+  <meta http-equiv="X-Content-Type-Options" content="nosniff" />
+  <meta http-equiv="Referrer-Policy" content="no-referrer" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Iron Dillo Labs</title>
+  <link rel="icon" type="image/svg+xml" href="/public/logo.svg" />
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&display=swap" rel="stylesheet" />
+  <script src="https://cdn.tailwindcss.com"></script>
+  <style>
+    :root {
+      --armadilloBlack: #1A1A1A;
+      --armadilloGray: #4A4A4A;
+      --oliveGreen: #6B7B3C;
+      --oliveDark: #55622F;
+      --offWhite: #F8F9FA;
+    }
+    body { font-family: 'Inter', sans-serif; }
+  </style>
+</head>
+<body class="bg-[var(--offWhite)] text-[var(--armadilloBlack)] min-h-screen">
+  <header class="p-4 flex items-center space-x-2">
+    <img src="/public/logo.svg" alt="Iron Dillo" class="h-8 w-8" />
+    <h1 class="text-xl font-semibold">Iron Dillo Labs</h1>
+  </header>
+  <main class="p-4">
+    <div id="terminal" class="bg-[var(--armadilloBlack)] text-[var(--offWhite)] p-4 h-64 overflow-y-auto"></div>
+    <button id="reset" class="mt-4 px-4 py-2 bg-[var(--oliveGreen)] text-[var(--offWhite)] rounded">Reset</button>
+  </main>
+  <script type="module" src="app.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add command dispatcher and default reset command
- add per-lab state management with reset hooks
- include reset button in Tailwind-based UI

## Testing
- `python -m py_compile terminal/cli.py labs/__init__.py labs/example/state.py`


------
https://chatgpt.com/codex/tasks/task_e_68a69602d36c8322a84573c993c833cd