### PR TITLE
Add command metadata, dispatcher validation, and category filters

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,7 @@
-# Mobile-app
+# Iron Dillo Mobile App
+
+Prototype assets for Iron Dillo Cybersecurity training.
+
+- `terminal/commands.yaml` defines command metadata with categories and lab scopes.
+- `terminal/dispatcher.js` checks metadata before execution and offers guidance when a command is out of scope.
+- `ui/index.html` presents category filters to highlight the learner's current mode using brand styling.

--- a/package.json
+++ b/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "mobile-app",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "node terminal/dispatcher.js ls intro > /tmp/out1 && node terminal/dispatcher.js ping intro > /tmp/out2 && node terminal/dispatcher.js ls networking > /tmp/out3"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs"
+}

--- a/terminal/commands.yaml
+++ b/terminal/commands.yaml
@@ -1,0 +1,9 @@
+- command: ls
+  category: filesystem
+  lab_scopes: [intro, filesystem]
+- command: pwd
+  category: navigation
+  lab_scopes: [intro, filesystem]
+- command: ping
+  category: network
+  lab_scopes: [networking]

--- a/terminal/dispatcher.js
+++ b/terminal/dispatcher.js
@@ -1,0 +1,51 @@
+const fs = require('fs');
+const path = require('path');
+
+function loadCommands() {
+  const yaml = fs.readFileSync(path.join(__dirname, 'commands.yaml'), 'utf8');
+  const lines = yaml.split(/\r?\n/);
+  const commands = [];
+  let current = null;
+  for (const line of lines) {
+    const trimmed = line.trim();
+    if (!trimmed) continue;
+    if (trimmed.startsWith('- command:')) {
+      if (current) commands.push(current);
+      current = { command: trimmed.split(':')[1].trim() };
+    } else if (trimmed.startsWith('category:')) {
+      if (current) current.category = trimmed.split(':')[1].trim();
+    } else if (trimmed.startsWith('lab_scopes:')) {
+      if (current) {
+        const list = trimmed.substring('lab_scopes:'.length).trim();
+        current.lab_scopes = list
+          .replace(/\[|\]/g, '')
+          .split(',')
+          .map(s => s.trim());
+      }
+    }
+  }
+  if (current) commands.push(current);
+  return commands;
+}
+
+const commandMeta = loadCommands();
+
+function dispatch(cmd, scope) {
+  const meta = commandMeta.find(c => c.command === cmd);
+  if (!meta) {
+    const categories = [...new Set(commandMeta.map(c => c.category))];
+    return `Unknown command "${cmd}". Try one from categories: ${categories.join(', ')}`;
+  }
+  if (!meta.lab_scopes.includes(scope)) {
+    return `The "${cmd}" command is not available in the "${scope}" lab. It belongs to "${meta.category}" and works in: ${meta.lab_scopes.join(', ')}`;
+  }
+  return `Executing ${cmd}...`;
+}
+
+if (require.main === module) {
+  const [cmd, scope] = process.argv.slice(2);
+  const message = dispatch(cmd, scope);
+  console.log(message);
+}
+
+module.exports = { dispatch };

--- a/ui/assets/favicon.svg
+++ b/ui/assets/favicon.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 50">
+  <path d="M10 40 Q50 0 90 40 Z" fill="#6B7B3C"/>
+  <circle cx="75" cy="25" r="8" fill="#55622F"/>
+  <rect x="20" y="40" width="10" height="10" fill="#4A4A4A"/>
+  <rect x="40" y="40" width="10" height="10" fill="#4A4A4A"/>
+  <rect x="60" y="40" width="10" height="10" fill="#4A4A4A"/>
+</svg>

--- a/ui/assets/logo.svg
+++ b/ui/assets/logo.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 50">
+  <path d="M10 40 Q50 0 90 40 Z" fill="#6B7B3C"/>
+  <circle cx="75" cy="25" r="8" fill="#55622F"/>
+  <rect x="20" y="40" width="10" height="10" fill="#4A4A4A"/>
+  <rect x="40" y="40" width="10" height="10" fill="#4A4A4A"/>
+  <rect x="60" y="40" width="10" height="10" fill="#4A4A4A"/>
+</svg>

--- a/ui/index.html
+++ b/ui/index.html
@@ -1,0 +1,75 @@
+<!DOCTYPE html>
+<html lang="en" class="h-full">
+<head>
+  <meta charset="utf-8" />
+  <title>Iron Dillo Cybersecurity</title>
+  <link rel="icon" href="assets/favicon.svg" type="image/svg+xml" />
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;700&display=swap" rel="stylesheet" />
+  <script src="https://cdn.tailwindcss.com"></script>
+  <script>
+    tailwind.config = {
+      theme: {
+        extend: {
+          colors: {
+            armadilloBlack: '#1A1A1A',
+            armadilloGray: '#4A4A4A',
+            oliveGreen: '#6B7B3C',
+            oliveDark: '#55622F',
+            offWhite: '#F8F9FA'
+          },
+          fontFamily: {
+            sans: ['Inter', 'sans-serif']
+          }
+        }
+      }
+    }
+  </script>
+  <script src="https://unpkg.com/alpinejs@3.x.x/dist/cdn.min.js" defer></script>
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; style-src 'self' 'unsafe-inline' https://cdn.tailwindcss.com https://fonts.googleapis.com; script-src 'self' https://unpkg.com; img-src 'self'; font-src 'self' https://fonts.gstatic.com https://fonts.googleapis.com;" />
+  <meta http-equiv="X-Content-Type-Options" content="nosniff" />
+  <meta http-equiv="Referrer-Policy" content="no-referrer" />
+  <meta http-equiv="X-Frame-Options" content="DENY" />
+</head>
+<body class="bg-offWhite text-armadilloBlack font-sans min-h-full">
+  <header class="p-4 flex items-center">
+    <img src="assets/logo.svg" alt="Iron Dillo logo" class="h-10 w-auto mr-2" />
+    <h1 class="text-xl font-bold">Iron Dillo Cybersecurity</h1>
+  </header>
+  <main class="p-4" x-data="categoryUI()">
+    <section class="mb-6 text-center">
+      <h2 class="text-3xl font-bold mb-4">Veteran-owned cybersecurity for East Texas</h2>
+      <p class="mb-4">Protecting individuals, small businesses, and rural operations in Lindale, Tyler, and beyond.</p>
+      <a href="#contact" class="bg-oliveGreen text-offWhite px-4 py-2 rounded">Get Protected</a>
+    </section>
+    <div class="mb-4 flex space-x-2 justify-center">
+      <template x-for="(color, cat) in categories" :key="cat">
+        <button @click="category = cat"
+          :style="{backgroundColor: category === cat ? color : '#4A4A4A', color: '#F8F9FA'}"
+          class="px-3 py-1 rounded capitalize">
+          <span x-text="cat"></span>
+        </button>
+      </template>
+    </div>
+    <div class="p-4 border border-armadilloGray rounded text-center" :style="{backgroundColor: activeColor + '22'}">
+      <p x-text="`Current mode: ${category}`"></p>
+    </div>
+  </main>
+  <script>
+    function categoryUI() {
+      return {
+        category: 'navigation',
+        categories: {
+          navigation: '#6B7B3C',
+          filesystem: '#55622F',
+          network: '#4A4A4A'
+        },
+        get activeColor() {
+          return this.categories[this.category]
+        }
+      }
+    }
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Define command metadata with categories and lab scopes
- Validate commands in dispatcher and return guided hints
- Introduce Tailwind/Alpine-based UI with category tabs and brand styling

## Testing
- `npm test`
- `node terminal/dispatcher.js ls intro`
- `node terminal/dispatcher.js ping intro`


------
https://chatgpt.com/codex/tasks/task_e_68a6960558408322878c09a476ae1397