### PR TITLE
Add user profile, contextual hints, and scoring manager

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.pyc

--- a/hints/__init__.py
+++ b/hints/__init__.py
@@ -1,0 +1,19 @@
+"""Hint loading utilities."""
+
+import json
+from pathlib import Path
+
+from typing import List
+
+PROFILE_PATH = Path(__file__).resolve().parents[1] / "user" / "profile.json"
+HINTS_DIR = Path(__file__).resolve().parent
+
+
+def load_hints(lab_name: str) -> List[str]:
+    """Load hints for the given lab based on the user's proficiency level."""
+    profile = json.loads(PROFILE_PATH.read_text())
+    proficiency = profile.get("proficiency", "beginner")
+
+    hints_file = HINTS_DIR / f"{lab_name}.json"
+    data = json.loads(hints_file.read_text())
+    return data.get(proficiency, [])

--- a/hints/lab1.json
+++ b/hints/lab1.json
@@ -1,0 +1,14 @@
+{
+  "beginner": [
+    "Start by scanning open ports to map the attack surface.",
+    "Look for obvious misconfigurations in exposed services."
+  ],
+  "intermediate": [
+    "Consider whether you can escalate privileges via insecure service configurations.",
+    "Review logs for patterns that might indicate previous exploitation attempts."
+  ],
+  "advanced": [
+    "Analyze the binary for potential buffer overflows using static analysis.",
+    "Craft a custom exploit payload targeting identified vulnerabilities."
+  ]
+}

--- a/scores/data.json
+++ b/scores/data.json
@@ -1,0 +1,5 @@
+{
+  "exploits": 0,
+  "fixes": 0,
+  "total": 0
+}

--- a/scores/manager.py
+++ b/scores/manager.py
@@ -1,0 +1,29 @@
+"""Simple scoring system for tracking user progress."""
+
+import json
+from pathlib import Path
+from typing import Dict
+
+
+class ScoreManager:
+    """Manage exploit and fix scores for a user."""
+
+    def __init__(self, storage: Path | str | None = None) -> None:
+        self.storage = Path(storage) if storage else Path(__file__).with_name("data.json")
+        if self.storage.exists():
+            self.scores: Dict[str, int] = json.loads(self.storage.read_text())
+        else:
+            self.scores = {"exploits": 0, "fixes": 0, "total": 0}
+            self._save()
+
+    def _save(self) -> None:
+        self.storage.write_text(json.dumps(self.scores, indent=2))
+
+    def record_success(self, kind: str) -> None:
+        """Record a successful action and update the score."""
+        if kind not in {"exploit", "fix"}:
+            raise ValueError("kind must be 'exploit' or 'fix'")
+        key = "exploits" if kind == "exploit" else "fixes"
+        self.scores[key] += 1
+        self.scores["total"] += 1
+        self._save()

--- a/user/profile.json
+++ b/user/profile.json
@@ -1,0 +1,3 @@
+{
+  "proficiency": "beginner"
+}


### PR DESCRIPTION
## Summary
- track user proficiency in `user/profile.json`
- load lab hints according to user proficiency
- manage exploit and fix scores with a persistent ScoreManager
- ignore Python cache files

## Testing
- `python -m pytest`
- `python - <<'PY'
from hints import load_hints
from scores.manager import ScoreManager
print(load_hints('lab1'))
sm = ScoreManager('scores/data.json')
sm.record_success('exploit')
sm.record_success('fix')
print(sm.scores)
PY`


------
https://chatgpt.com/codex/tasks/task_e_68a696081bb0832284102293f2835a50