### PR TITLE
Add reflected XSS lab and terminal scaffolding

### DIFF
--- a/.github/ISSUE_TEMPLATE/new_lab.md
+++ b/.github/ISSUE_TEMPLATE/new_lab.md
@@ -1,0 +1,12 @@
+---
+name: New Lab
+about: Propose a new training lab
+title: "[Lab]"
+labels: enhancement
+---
+
+**Module:**
+
+**Difficulty:**
+
+**Goal:**

--- a/.github/PROJECT.md
+++ b/.github/PROJECT.md
@@ -1,0 +1,10 @@
+# Project Setup
+
+Create a GitHub Project with the following fields:
+- **Type**
+- **Module**
+- **Difficulty**
+- **Status**
+- **Iteration**
+
+Include Kanban and Roadmap views so progress can be tracked.

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 __pycache__/
 *.pyc
+node_modules/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,13 @@
+# Contributing
+
+## Authoring a Lab
+
+1. Add a YAML file under `labs/` describing routes, checks, and a short quiz.
+2. Create matching templates in `public/` for the insecure version and `secure/` for the patched version.
+3. Update `terminal/commands.yaml` and `terminal/dispatcher.js` if new commands are required.
+4. Verify with `npm test` and run the app in both demo and secure modes.
+
+## Issue Template
+
+Use the **New Lab** issue template when proposing a module.
+Provide the module name, difficulty, and learning goal.

--- a/README.md
+++ b/README.md
@@ -48,3 +48,14 @@ This repository hosts demo pages for illustrating common security pitfalls and t
 - `SECURITY_DEMO.md` provides side-by-side code snippets explaining each fix.
 
 Veteran-owned cybersecurity for East Texas small businesses, individuals, and rural operations — proudly serving Lindale and Tyler.
+## 60-second Smoke Test
+
+### Demo mode
+- `/` shows a directory listing.
+- `/index.html` returns 200.
+- `/does-not-exist` returns 404.
+
+### Secure mode
+- `/` returns 200 if `index.html` exists, otherwise 404.
+- Errors are generic; stack traces are hidden.
+- Responses include `X-Content-Type-Options: nosniff` and a basic `Content-Security-Policy`.

--- a/labs/xss-reflected-101.yaml
+++ b/labs/xss-reflected-101.yaml
@@ -1,0 +1,17 @@
+id: xss-reflected-101
+title: Reflected XSS 101
+routes:
+  insecure: /labs/xss-101.html
+  secure: /secure/labs/xss-101.html
+checks:
+  - path: /labs/xss-101.html?q=<script>alert(1)</script>
+    expect: '<script>alert(1)</script>'
+  - path: /secure/labs/xss-101.html?q=<script>alert(1)</script>
+    expect: '&lt;script&gt;alert(1)&lt;/script&gt;'
+quiz:
+  question: Which header helps mitigate reflected XSS?
+  options:
+    - Content-Security-Policy
+    - X-Powered-By
+    - Server
+  answer: Content-Security-Policy

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "test": "node -e \"const d=require('./terminal/dispatcher'); const assert=require('assert'); assert.strictEqual(d.dispatch('ls','intro'),'Executing ls...'); assert.ok(d.dispatch('ping','intro').includes('not available')); assert.ok(d.dispatch('ls','networking').includes('not available')); console.log('tests passed');\""
+    "test": "node terminal/test.js"
   },
   "keywords": [],
   "author": "",

--- a/public/labs/xss-101.html
+++ b/public/labs/xss-101.html
@@ -1,0 +1,46 @@
+<!DOCTYPE html>
+<html lang="en" class="h-full">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Reflected XSS Demo</title>
+  <link rel="icon" type="image/svg+xml" href="../favicon.svg" />
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&display=swap" rel="stylesheet" />
+  <script src="https://cdn.tailwindcss.com"></script>
+  <script>
+    tailwind.config = {
+      theme: {
+        extend: {
+          colors: {
+            armadilloBlack: '#1A1A1A',
+            armadilloGray: '#4A4A4A',
+            oliveGreen: '#6B7B3C',
+            oliveDark: '#55622F',
+            offWhite: '#F8F9FA'
+          },
+          fontFamily: {
+            sans: ['Inter', 'sans-serif']
+          }
+        }
+      }
+    }
+  </script>
+</head>
+<body class="h-full font-sans bg-offWhite text-armadilloBlack p-4">
+  <header class="mb-4">
+    <img src="../logo.svg" alt="Iron Dillo logo" class="h-8" />
+  </header>
+  <form class="mb-4">
+    <label for="q" class="block mb-2">Search</label>
+    <input id="q" name="q" class="border p-2 w-full" />
+  </form>
+  <p id="result" class="mt-4"></p>
+  <script>
+    const params = new URLSearchParams(location.search);
+    const q = params.get('q') || '';
+    document.getElementById('result').innerHTML = q;
+  </script>
+</body>
+</html>

--- a/secure/labs/xss-101.html
+++ b/secure/labs/xss-101.html
@@ -1,0 +1,48 @@
+<!DOCTYPE html>
+<html lang="en" class="h-full">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Reflected XSS Demo (Secure)</title>
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self'" />
+  <meta http-equiv="X-Content-Type-Options" content="nosniff" />
+  <link rel="icon" type="image/svg+xml" href="../favicon.svg" />
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&display=swap" rel="stylesheet" />
+  <script src="https://cdn.tailwindcss.com"></script>
+  <script>
+    tailwind.config = {
+      theme: {
+        extend: {
+          colors: {
+            armadilloBlack: '#1A1A1A',
+            armadilloGray: '#4A4A4A',
+            oliveGreen: '#6B7B3C',
+            oliveDark: '#55622F',
+            offWhite: '#F8F9FA'
+          },
+          fontFamily: {
+            sans: ['Inter', 'sans-serif']
+          }
+        }
+      }
+    }
+  </script>
+</head>
+<body class="h-full font-sans bg-offWhite text-armadilloBlack p-4">
+  <header class="mb-4">
+    <img src="../logo.svg" alt="Iron Dillo logo" class="h-8" />
+  </header>
+  <form class="mb-4">
+    <label for="q" class="block mb-2">Search</label>
+    <input id="q" name="q" class="border p-2 w-full" />
+  </form>
+  <p id="result" class="mt-4"></p>
+  <script>
+    const params = new URLSearchParams(location.search);
+    const q = params.get('q') || '';
+    document.getElementById('result').textContent = q;
+  </script>
+</body>
+</html>

--- a/terminal/commands.yaml
+++ b/terminal/commands.yaml
@@ -1,9 +1,29 @@
-- command: ls
-  category: filesystem
-  lab_scopes: [intro, filesystem]
-- command: pwd
-  category: navigation
-  lab_scopes: [intro, filesystem]
-- command: ping
+- command: help
+  category: core
+  lab_scopes: [xss-reflected-101]
+  output: "Available commands: help, curl, secure_fix, nmap, sqlmap"
+  why: "Use help to see supported commands in this lab."
+- command: curl
   category: network
-  lab_scopes: [networking]
+  lab_scopes: [xss-reflected-101]
+  output: "Simulated request sent."
+  why: "Replays the vulnerable request."
+- command: secure_fix
+  category: fix
+  lab_scopes: [xss-reflected-101]
+  output: "Escaping applied and CSP enabled."
+  why: "Mitigates the reflected XSS."
+- command: nmap
+  category: fun
+  lab_scopes: [xss-reflected-101]
+  output: |-
+    Starting Nmap 7.93 ( https://nmap.org )
+    Not shown: 99 closed ports
+    PORT   STATE SERVICE
+    80/tcp open  http
+  why: "Recon tools reveal running services."
+- command: sqlmap
+  category: fun
+  lab_scopes: [xss-reflected-101]
+  output: "sqlmap identified a vulnerable parameter."
+  why: "Automated scanners can flag injection points."

--- a/terminal/dispatcher.js
+++ b/terminal/dispatcher.js
@@ -9,22 +9,28 @@ function loadCommands() {
 
 const commandMeta = loadCommands();
 
-function dispatch(cmd, scope) {
+function dispatch(input, scope, mode = 'beginner') {
+  const [cmd] = (input || '').trim().split(/\s+/);
   const meta = commandMeta.find(c => c.command === cmd);
   if (!meta) {
-    const categories = [...new Set(commandMeta.map(c => c.category))];
-    return `Unknown command "${cmd}". Try one from categories: ${categories.join(', ')}`;
+    if (mode === 'beginner') {
+      return { output: '', hint: 'Unknown command. Type "help" for options.' };
+    }
+    return { output: '' };
   }
   if (!meta.lab_scopes.includes(scope)) {
-    return `The "${cmd}" command is not available in the "${scope}" lab. It belongs to "${meta.category}" and works in: ${meta.lab_scopes.join(', ')}`;
+    if (mode === 'beginner') {
+      return { output: '', hint: `"${cmd}" is not available in this lab.` };
+    }
+    return { output: '' };
   }
-  return `Executing ${cmd}...`;
+  return { output: meta.output, why: meta.why };
 }
 
 if (require.main === module) {
-  const [cmd, scope] = process.argv.slice(2);
-  const message = dispatch(cmd, scope);
-  console.log(message);
+  const [input, scope, mode] = process.argv.slice(2);
+  const message = dispatch(input, scope, mode);
+  console.log(JSON.stringify(message, null, 2));
 }
 
 module.exports = { dispatch };

--- a/terminal/test.js
+++ b/terminal/test.js
@@ -1,0 +1,16 @@
+const assert = require('assert');
+const d = require('./dispatcher');
+
+let r = d.dispatch('help', 'xss-reflected-101');
+assert.ok(r.output.includes('Available'));
+
+r = d.dispatch('unknown', 'xss-reflected-101');
+assert.ok(r.hint);
+
+r = d.dispatch('curl', 'otherlab', 'beginner');
+assert.ok(r.hint);
+
+r = d.dispatch('unknown', 'xss-reflected-101', 'advanced');
+assert.strictEqual(r.hint, undefined);
+
+console.log('tests passed');

--- a/ui/lab.html
+++ b/ui/lab.html
@@ -1,0 +1,101 @@
+<!DOCTYPE html>
+<html lang="en" class="h-full">
+<head>
+  <meta charset="utf-8" />
+  <title>Lab</title>
+  <link rel="icon" href="assets/favicon.svg" type="image/svg+xml" />
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;700&display=swap" rel="stylesheet" />
+  <script src="https://cdn.tailwindcss.com"></script>
+  <script>
+    tailwind.config = {
+      theme: {
+        extend: {
+          colors: {
+            armadilloBlack: '#1A1A1A',
+            armadilloGray: '#4A4A4A',
+            oliveGreen: '#6B7B3C',
+            oliveDark: '#55622F',
+            offWhite: '#F8F9FA'
+          },
+          fontFamily: {
+            sans: ['Inter', 'sans-serif']
+          }
+        }
+      }
+    }
+  </script>
+  <script src="https://unpkg.com/alpinejs@3.x.x/dist/cdn.min.js" defer></script>
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; style-src 'self' 'unsafe-inline' https://cdn.tailwindcss.com https://fonts.googleapis.com; script-src 'self' https://unpkg.com; img-src 'self'; font-src 'self' https://fonts.gstatic.com https://fonts.googleapis.com;" />
+  <meta http-equiv="X-Content-Type-Options" content="nosniff" />
+  <meta http-equiv="Referrer-Policy" content="no-referrer" />
+  <meta http-equiv="X-Frame-Options" content="DENY" />
+</head>
+<body class="h-full font-sans bg-offWhite text-armadilloBlack" x-data="lab()">
+  <div class="h-full flex flex-col lg:flex-row">
+    <section class="lg:w-1/2 h-1/2 lg:h-full flex flex-col border-b lg:border-b-0 lg:border-r border-armadilloGray">
+      <div class="flex-1 overflow-y-auto bg-armadilloBlack text-offWhite p-2 whitespace-pre-wrap" x-text="terminal"></div>
+      <input type="text" placeholder="Type command" class="p-2 border-t border-armadilloGray" @keydown.enter.prevent="handle($event.target.value); $event.target.value=''" />
+      <p class="text-armadilloGray p-2" x-show="hint" x-text="hint"></p>
+    </section>
+    <section class="lg:w-1/2 h-1/2 lg:h-full flex flex-col">
+      <iframe :src="preview" class="flex-1 border-b border-armadilloGray"></iframe>
+      <div class="p-2 flex items-center justify-between">
+        <button class="px-4 py-2 bg-oliveGreen text-offWhite rounded" @click="reset">Reset Lab</button>
+        <button class="px-4 py-2 bg-armadilloGray text-offWhite rounded" @click="showWhy = !showWhy">Why it worked / How to fix</button>
+      </div>
+      <div class="p-4 border-t border-armadilloGray" x-show="showWhy">
+        <p x-text="why"></p>
+      </div>
+    </section>
+  </div>
+  <script>
+    function lab() {
+      return {
+        scope: 'xss-reflected-101',
+        stage: 'explore',
+        terminal: '',
+        hint: '',
+        why: '',
+        showWhy: false,
+        preview: '/labs/xss-101.html',
+        handle(cmd) {
+          const res = dispatcher(cmd, this.scope);
+          this.terminal += `$ ${cmd}\n${res.output}\n`;
+          this.hint = res.hint || '';
+          if (res.why) this.why = res.why;
+          if (cmd === 'curl' && this.stage === 'explore') {
+            this.preview = '/labs/xss-101.html?q=<script>alert(1)</script>';
+            this.stage = 'exploit';
+          } else if (cmd === 'secure_fix' && this.stage === 'exploit') {
+            this.preview = '/secure/labs/xss-101.html?q=<script>alert(1)</script>';
+            this.stage = 'verify';
+          }
+        },
+        reset() {
+          this.stage = 'explore';
+          this.terminal = '';
+          this.hint = '';
+          this.why = '';
+          this.preview = '/labs/xss-101.html';
+        }
+      }
+    }
+    function dispatcher(cmd, scope, mode='beginner') {
+      const commands = {
+        help: { output: 'help, curl, secure_fix, nmap, sqlmap', why: 'Use help to see commands.' },
+        curl: { output: 'curl executed', why: 'Shows reflected output.' },
+        secure_fix: { output: 'Applied escaping and CSP.', why: 'Fixes the vulnerability.' },
+        nmap: { output: 'Starting Nmap...\n80/tcp open http', why: 'Reconnaissance example.' },
+        sqlmap: { output: 'sqlmap found injection point', why: 'Automated testing example.' }
+      };
+      const meta = commands[cmd];
+      if (!meta) {
+        return mode === 'beginner' ? { output: '', hint: 'Unknown command. Try "help".' } : { output: '' };
+      }
+      return meta;
+    }
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- introduce reflected XSS 101 lab with insecure and secure templates
- expand terminal commands and dispatcher with lab scoping and guidance
- document lab authoring steps and add issue template and smoke tests

## Testing
- `npm test`
- `curl -i http://localhost:3000/nope`
- `SECURE=true node server.js` then `curl -i http://localhost:3000/` and `/nope`


------
https://chatgpt.com/codex/tasks/task_e_68a71696add08322b9d8226a51f8526a