### PR TITLE
Add React Native prototype with Iron Dillo branding

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ Prototype assets for Iron Dillo Cybersecurity training.
 - `terminal/commands.yaml` defines command metadata with categories and lab scopes.
 - `terminal/dispatcher.js` checks metadata before execution and offers guidance when a command is out of scope.
 - `ui/index.html` presents category filters to highlight the learner's current mode using brand styling.
+- `react-native/` contains a minimal Expo-based React Native app prototype with Iron Dillo branding.
 # Demo Server Security Modes
 
 This repository demonstrates directory indexing and detailed error pages in a demo environment and provides a secure mode that disables listings and masks errors.

--- a/react-native/App.js
+++ b/react-native/App.js
@@ -1,0 +1,44 @@
+import React from 'react';
+import { SafeAreaView, StatusBar, StyleSheet, Text, View } from 'react-native';
+
+export default function App() {
+  return (
+    <SafeAreaView style={styles.container}>
+      <StatusBar barStyle="light-content" />
+      <View style={styles.hero}>
+        <Text style={styles.title}>Iron Dillo</Text>
+        <Text style={styles.subtitle}>
+          Veteran-owned cybersecurity for East Texas small businesses, individuals, and rural operations.
+        </Text>
+      </View>
+    </SafeAreaView>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: '#1A1A1A', // armadilloBlack
+    justifyContent: 'center',
+    alignItems: 'center',
+    padding: 16,
+  },
+  hero: {
+    backgroundColor: '#F8F9FA', // offWhite
+    padding: 24,
+    borderRadius: 8,
+  },
+  title: {
+    fontSize: 24,
+    color: '#6B7B3C', // oliveGreen
+    fontFamily: 'Inter',
+    marginBottom: 8,
+    textAlign: 'center',
+  },
+  subtitle: {
+    fontSize: 16,
+    color: '#4A4A4A', // armadilloGray
+    fontFamily: 'Inter',
+    textAlign: 'center',
+  },
+});

--- a/react-native/app.json
+++ b/react-native/app.json
@@ -1,0 +1,16 @@
+{
+  "expo": {
+    "name": "Iron Dillo",
+    "slug": "iron-dillo",
+    "version": "1.0.0",
+    "orientation": "portrait",
+    "icon": "../logo.svg",
+    "splash": {
+      "backgroundColor": "#1A1A1A"
+    },
+    "updates": {
+      "fallbackToCacheTimeout": 0
+    },
+    "assetBundlePatterns": ["**/*"]
+  }
+}

--- a/react-native/babel.config.js
+++ b/react-native/babel.config.js
@@ -1,0 +1,6 @@
+module.exports = function(api) {
+  api.cache(true);
+  return {
+    presets: ['babel-preset-expo'],
+  };
+};

--- a/react-native/package.json
+++ b/react-native/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "iron-dillo-app",
+  "version": "0.1.0",
+  "private": true,
+  "main": "App.js",
+  "scripts": {
+    "start": "expo start",
+    "android": "expo run:android",
+    "ios": "expo run:ios",
+    "web": "expo start --web"
+  },
+  "dependencies": {
+    "expo": "^49.0.0",
+    "expo-status-bar": "~1.4.0",
+    "react": "18.2.0",
+    "react-dom": "18.2.0",
+    "react-native": "0.72.0",
+    "react-native-web": "~0.19.0"
+  }
+}


### PR DESCRIPTION
## Summary
- scaffold Expo-based React Native app with Iron Dillo colors and messaging
- document new React Native prototype in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68abf1ff38148322a3de3dd6e02b4596